### PR TITLE
Added build query option for searching raw records

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -6,7 +6,7 @@ file --mime-type ./* bin/* | grep 'text/x-shellscript' | cut -d':' -f1 |
     xargs -r shellcheck
 
 echo -e "\n=== RuboCop"
-rubocop
+rubocop -A
 
 echo -e "\n=== RSpec"
 rspec

--- a/bin/test
+++ b/bin/test
@@ -6,7 +6,7 @@ file --mime-type ./* bin/* | grep 'text/x-shellscript' | cut -d':' -f1 |
     xargs -r shellcheck
 
 echo -e "\n=== RuboCop"
-rubocop -A
+rubocop
 
 echo -e "\n=== RSpec"
 rspec

--- a/lib/register_sources_dk/repositories/deltagerperson_repository.rb
+++ b/lib/register_sources_dk/repositories/deltagerperson_repository.rb
@@ -79,7 +79,7 @@ module RegisterSourcesDk
         true
       end
 
-      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/CyclomaticComplexity
       def build_get_by_bods_identifiers(identifiers)
         enheds_nummers = [] # enhedsNummer
         cvrs = [] # virksomhedSummariskRelation.virksomhed.cvrNummer
@@ -100,23 +100,29 @@ module RegisterSourcesDk
               {
                 bool: {
                   must: [
-                    { match: { 'Vrdeltagerperson.enhedsNummer': { query: id.to_i } } },
-                  ],
-                },
+                    { match: { 'Vrdeltagerperson.enhedsNummer': { query: id.to_i } } }
+                  ]
+                }
               }
             } + cvrs.map do |id|
               {
                 bool: {
                   must: [
-                    { match: { 'Vrdeltagerperson.virksomhedSummariskRelation.virksomhed.cvrNummer': { query: id.to_i } } },
-                  ],
-                },
+                    {
+                      match: {
+                        'Vrdeltagerperson.virksomhedSummariskRelation.virksomhed.cvrNummer': {
+                          query: id.to_i
+                        }
+                      }
+                    }
+                  ]
+                }
               }
-            end,
-          },
+            end
+          }
         }
       end
-      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       private
 
@@ -132,7 +138,7 @@ module RegisterSourcesDk
         SearchResults.new(
           mapped.sort_by(&:score).reverse,
           total_count:,
-          aggs: results['aggregations'],
+          aggs: results['aggregations']
         )
       end
 

--- a/lib/register_sources_dk/repositories/deltagerperson_repository.rb
+++ b/lib/register_sources_dk/repositories/deltagerperson_repository.rb
@@ -9,7 +9,7 @@ module RegisterSourcesDk
       ElasticsearchError = Class.new(StandardError)
 
       SearchResult = Struct.new(:record, :score)
-      
+
       class SearchResults < Array
         def initialize(arr, total_count: nil, aggs: nil)
           @total_count = total_count || arr.to_a.count

--- a/lib/register_sources_dk/repositories/deltagerperson_repository.rb
+++ b/lib/register_sources_dk/repositories/deltagerperson_repository.rb
@@ -9,11 +9,24 @@ module RegisterSourcesDk
       ElasticsearchError = Class.new(StandardError)
 
       SearchResult = Struct.new(:record, :score)
+      
+      class SearchResults < Array
+        def initialize(arr, total_count: nil, aggs: nil)
+          @total_count = total_count || arr.to_a.count
+          @aggs = aggs
+
+          super(arr)
+        end
+
+        attr_reader :total_count, :aggs
+      end
 
       def initialize(client: Config::ELASTICSEARCH_CLIENT, index: Config::ELASTICSEARCH_INDEX)
         @client = client
         @index = index
       end
+
+      attr_reader :client, :index
 
       def get(etag)
         process_results(
@@ -67,7 +80,7 @@ module RegisterSourcesDk
       end
 
       # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-      def get_by_bods_identifiers(identifiers, per_page: nil)
+      def build_get_by_bods_identifiers(identifiers)
         enheds_nummers = [] # enhedsNummer
         cvrs = [] # virksomhedSummariskRelation.virksomhed.cvrNummer
         identifiers.each do |identifier|
@@ -79,55 +92,48 @@ module RegisterSourcesDk
           end
         end
 
-        return [] if cvrs.empty? && enheds_nummers.empty?
+        return if cvrs.empty? && enheds_nummers.empty?
 
-        process_results(
-          client.search(
-            index:,
-            body: {
-              query: {
+        {
+          bool: {
+            should: enheds_nummers.map { |id|
+              {
                 bool: {
-                  should: enheds_nummers.map { |id|
-                    {
-                      bool: {
-                        must: [
-                          { match: { 'Vrdeltagerperson.enhedsNummer': { query: id.to_i } } }
-                        ]
-                      }
-                    }
-                  } + cvrs.map do |id|
-                    {
-                      bool: {
-                        must: [
-                          { match: { 'Vrdeltagerperson.virksomhedSummariskRelation.virksomhed.cvrNummer': {
-                            query: id.to_i
-                          } } }
-                        ]
-                      }
-                    }
-                  end
-                }
-              },
-              size: per_page || 10_000
-            }
-          )
-        ).map(&:record)
+                  must: [
+                    { match: { 'Vrdeltagerperson.enhedsNummer': { query: id.to_i } } },
+                  ],
+                },
+              }
+            } + cvrs.map do |id|
+              {
+                bool: {
+                  must: [
+                    { match: { 'Vrdeltagerperson.virksomhedSummariskRelation.virksomhed.cvrNummer': { query: id.to_i } } },
+                  ],
+                },
+              }
+            end,
+          },
+        }
       end
       # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       private
 
-      attr_reader :client, :index
-
       def process_results(results)
         hits = results.dig('hits', 'hits') || []
         hits = hits.sort { |hit| hit['_score'] }.reverse # rubocop:disable Lint/UnexpectedBlockArity # FIXME
+        total_count = results.dig('hits', 'total', 'value') || 0
 
         mapped = hits.map do |hit|
           SearchResult.new(map_es_record(hit['_source']), hit['_score'])
         end
 
-        mapped.sort_by(&:score).reverse
+        SearchResults.new(
+          mapped.sort_by(&:score).reverse,
+          total_count:,
+          aggs: results['aggregations'],
+        )
       end
 
       def map_es_record(record)

--- a/spec/integration/deltagerperson_repository_spec.rb
+++ b/spec/integration/deltagerperson_repository_spec.rb
@@ -5,8 +5,6 @@ require 'register_sources_dk/repositories/deltagerperson_repository'
 require 'register_sources_dk/services/es_index_creator'
 require 'register_sources_dk/structs/record'
 
-BodsIdentifier = Struct.new(:id, :schemeName)
-
 RSpec.describe RegisterSourcesDk::Repositories::DeltagerpersonRepository do
   subject { described_class.new(client: es_client, index:) }
 
@@ -44,25 +42,7 @@ RSpec.describe RegisterSourcesDk::Repositories::DeltagerpersonRepository do
       expect(subject.get(record.etag)).to eq record
 
       # When records do not exist
-      expect(subject.get('missing')).to be_nil
-
-      # Check identifiers when 'DK Centrale Virksomhedsregister'
-      identifiers = [
-        BodsIdentifier.new(2, 'DK Centrale Virksomhedsregister')
-      ]
-
-      results = subject.get_by_bods_identifiers(identifiers)
-
-      expect(results).to eq [record2]
-
-      # Check identifiers when 'Danish Central Business Register'
-      identifiers = [
-        BodsIdentifier.new(1_234_567, 'Danish Central Business Register')
-      ]
-
-      results = subject.get_by_bods_identifiers(identifiers)
-
-      expect(results).to eq [record]
+      expect(subject.get("missing")).to be_nil
     end
   end
 end

--- a/spec/integration/deltagerperson_repository_spec.rb
+++ b/spec/integration/deltagerperson_repository_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RegisterSourcesDk::Repositories::DeltagerpersonRepository do
       expect(subject.get(record.etag)).to eq record
 
       # When records do not exist
-      expect(subject.get("missing")).to be_nil
+      expect(subject.get('missing')).to be_nil
     end
   end
 end

--- a/spec/unit/repositories/deltagerperson_repository_spec.rb
+++ b/spec/unit/repositories/deltagerperson_repository_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe RegisterSourcesDk::Repositories::DeltagerpersonRepository do
     it 'builds query for searching by bods identifiers' do
       identifiers = [
         BodsIdentifier.new(2, 'DK Centrale Virksomhedsregister'),
-        BodsIdentifier.new(1_234_567, 'Danish Central Business Register'),
+        BodsIdentifier.new(1_234_567, 'Danish Central Business Register')
       ]
 
       query = subject.build_get_by_bods_identifiers(identifiers)
@@ -283,12 +283,12 @@ RSpec.describe RegisterSourcesDk::Repositories::DeltagerpersonRepository do
                     {
                       match: {
                         'Vrdeltagerperson.enhedsNummer': {
-                          query: 2,
-                        },
-                      },
-                    },
-                  ],
-                },
+                          query: 2
+                        }
+                      }
+                    }
+                  ]
+                }
               },
               {
                 bool: {
@@ -296,16 +296,16 @@ RSpec.describe RegisterSourcesDk::Repositories::DeltagerpersonRepository do
                     {
                       match: {
                         'Vrdeltagerperson.virksomhedSummariskRelation.virksomhed.cvrNummer': {
-                          query: 1_234_567,
-                        },
-                      },
-                    },
-                  ],
-                },
-              },
-            ],
-          },
-        },
+                          query: 1_234_567
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
       )
     end
   end

--- a/spec/unit/repositories/deltagerperson_repository_spec.rb
+++ b/spec/unit/repositories/deltagerperson_repository_spec.rb
@@ -2,6 +2,9 @@
 
 require 'json'
 require 'register_sources_dk/repositories/deltagerperson_repository'
+require 'register_sources_dk/structs/record'
+
+BodsIdentifier = Struct.new(:id, :schemeName)
 
 RSpec.describe RegisterSourcesDk::Repositories::DeltagerpersonRepository do
   subject { described_class.new(client:, index:) }
@@ -258,6 +261,52 @@ RSpec.describe RegisterSourcesDk::Repositories::DeltagerpersonRepository do
 
         expect { subject.store([record]) }.to raise_error(described_class::ElasticsearchError)
       end
+    end
+  end
+
+  describe '#build_get_by_bods_identifiers' do
+    it 'builds query for searching by bods identifiers' do
+      identifiers = [
+        BodsIdentifier.new(2, 'DK Centrale Virksomhedsregister'),
+        BodsIdentifier.new(1_234_567, 'Danish Central Business Register'),
+      ]
+
+      query = subject.build_get_by_bods_identifiers(identifiers)
+
+      expect(query).to eq(
+        {
+          bool: {
+            should: [
+              {
+                bool: {
+                  must: [
+                    {
+                      match: {
+                        'Vrdeltagerperson.enhedsNummer': {
+                          query: 2,
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                bool: {
+                  must: [
+                    {
+                      match: {
+                        'Vrdeltagerperson.virksomhedSummariskRelation.virksomhed.cvrNummer': {
+                          query: 1_234_567,
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      )
     end
   end
 end


### PR DESCRIPTION
The Register needs to be able to combine and submit the queries as a single query over multiple indexes, to properly paginate raw record requests over multiple sources.

To allow this, the query for raw records is now built and returned instead of being performed inside the repository.